### PR TITLE
Add setting: memo-life-for-you.openMarkdownPreviewUseMPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-memo-life-for-you" extension will be documented in this file.
 
+# 0.4.8
+
+* Add setting: `memo-life-for-you.openMarkdownPreviewUseMPE`: If `memo-life-for-you.openMarkdownPreview` is set to `true`, use `Markdown Preview Enhanced` (https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced) to open preview (default: false)"
+
 # 0.4.7
 
 * Add setting: `memo-life-for-you.memoNewFilenameFromClipboard`: Use the string stored in OS clipboard as the name of the newly created file (defaut: false),

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ This extension contributes the following settings:
 * `memo-life-for-you.memoNewFilenameFromClipboard`: Use the string stored in OS clipboard as the name of the newly created file (defaut: false),
 * `memo-life-for-you.memoNewFilenameFromSelection`: Use the selected string on vscode as the name of the newly create file (default: false),
 * `memo-life-for-you.memoNewFilNameDateSuffix`: Add a date related suffix after filename prefix (YYYY-MM-DD). The added string is passed to datefns.format(). See: https://date-fns.org/v1.29.0/docs/format (default: empty). 
+* `memo-life-for-you.openMarkdownPreviewUseMPE`: If `memo-life-for-you.openMarkdownPreview` is set to `true`, use `Markdown Preview Enhanced` (https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced) to open preview (default: false)"
 
     example: 
 

--- a/i18n/jpn/package.i18n.json
+++ b/i18n/jpn/package.i18n.json
@@ -24,8 +24,9 @@
     "listSortOrder.desc": "Controls the order of Memo: List display. Selectable from `filename` or `birthtime` or `mtime`",
     "memoGrepUseRipGrepConfigFile.desc": "Do you want ripgrep to work with the configuration file (.ripgreprc)",
     "memoGrepUseRipGrepConfigFilePath.desc": "If you set `memoGrepUseRipGrepConfigFile` to `ture` and want to use ripgrep config file located further in a specific place, set the path of config file",
-    "memoTodoUserePattern": "Todo として認識するためのパターンを定義します (default: ^.*@todo.*?:)",
+    "memoTodoUserePattern.desc": "Todo として認識するためのパターンを定義します (default: ^.*@todo.*?:)",
     "memoNewFilenameFromClipboard.desc": "OS のクリップボードに格納された文字列を新しく作成するファイルの名前として使用する",
 	"memoNewFilenameFromSelection.desc": "vscode 上で選択した文字列を新しく作成するファイルの名前として使用する",
-	"memoNewFilNameDateSuffix.desc": "ファイル名（YYYY-MM-DD）の後に日付関連の接尾辞を追加します。追加された文字列は、datefns.format() に渡されます。詳細は、https://date-fns.org/v1.29.0/docs/format を参照してください"
+    "memoNewFilNameDateSuffix.desc": "ファイル名（YYYY-MM-DD）の後に日付関連の接尾辞を追加します。追加された文字列は、datefns.format() に渡されます。詳細は、https://date-fns.org/v1.29.0/docs/format を参照してください",
+    "openMarkdownPreviewUseMPE.desc": "`memo-life-for-you.openMarkdownPreview` に `true` がセットされている場合、`Markdown Preview Enhanced` (https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced) を使ってプレビューを開く (default: false)"
 }

--- a/package.json
+++ b/package.json
@@ -214,6 +214,11 @@
           "type": "string",
           "default": "",
           "description": "%memoNewFilNameDateSuffix.desc%"
+        },
+        "memo-life-for-you.openMarkdownPreviewUseMPE": {
+          "type": "boolean",
+          "default": false,
+          "description": "%openMarkdownPreviewUseMPE.desc%"
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -24,5 +24,6 @@
     "listSortOrder.desc": "Controls the order of Memo: List display. Selectable from `filename` or `birthtime` or `mtime`",
     "memoGrepUseRipGrepConfigFile.desc": "Do you want ripgrep to work with the configuration file (.ripgreprc)",
     "memoGrepUseRipGrepConfigFilePath.desc": "If you set `memoGrepUseRipGrepConfigFile` to `ture` and want to use ripgrep config file located further in a specific place, set the path of config file",
-    "memoTodoUserePattern": "Define a pattern to recognize as todo (default: ^.*@todo.*?:)"
+    "memoTodoUserePattern.desc": "Define a pattern to recognize as todo (default: ^.*@todo.*?:)",
+    "openMarkdownPreviewUseMPE.desc": "If `memo-life-for-you.openMarkdownPreview` is set to `true`, use `Markdown Preview Enhanced` (https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced) to open preview (default: false)"
 }

--- a/src/memoConfigure.ts
+++ b/src/memoConfigure.ts
@@ -52,7 +52,8 @@ export class memoConfigure {
     public memoTodoUserePattern: string;
     public memoNewFilenameFromClipboard: boolean;
     public memoNewFilenameFromSelection: boolean;
-    public memoNewFilNameDateSuffix: string;;
+    public memoNewFilNameDateSuffix: string;
+    public openMarkdownPreviewUseMPE: boolean;
     
     public options: vscode.QuickPickOptions = {
         ignoreFocusOut: true,
@@ -173,6 +174,7 @@ export class memoConfigure {
         this.memoNewFilenameFromClipboard = vscode.workspace.getConfiguration('memo-life-for-you').get<boolean>('memoNewFilenameFromClipboard');
         this.memoNewFilenameFromSelection = vscode.workspace.getConfiguration('memo-life-for-you').get<boolean>('memoNewFilenameFromSelection');
         this.memoNewFilNameDateSuffix = vscode.workspace.getConfiguration('memo-life-for-you').get<string>('memoNewFilNameDateSuffix');
+        this.openMarkdownPreviewUseMPE = vscode.workspace.getConfiguration('memo-life-for-you').get<boolean>('openMarkdownPreviewUseMPE');
     }
 
     get onDidChange() {

--- a/src/memoEdit.ts
+++ b/src/memoEdit.ts
@@ -30,6 +30,7 @@ export class memoEdit extends memoConfigure  {
         let dirlist: string[] = [];
         let openMarkdownPreview: boolean = this.memoEditOpenMarkdown;
         let listMarkdownPreview: boolean = this.memoEditPreviewMarkdown;
+        let openMarkdownPreviewUseMPE: boolean = this.openMarkdownPreviewUseMPE;
         let isEnabled: boolean = false; // Flag: opened Markdown Preview (Markdown Enhance Preview)
         // console.log("memodir = ", memodir)
 
@@ -222,44 +223,21 @@ export class memoEdit extends memoConfigure  {
                     })
                 }
             }
-        }).then(async function (selected) {   // When selected with the mouse
-            if (selected == null) {
-                if (listMarkdownPreview) {
-                    //キャンセルした時の close 処理
-                    await vscode.commands.executeCommand('workbench.action.closeActiveEditor').then(() => {
-                            vscode.commands.executeCommand('workbench.action.focusPreviousGroup').then(() => {
-                                    // vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-                            });
+        }).then(async () => {
+            if (openMarkdownPreview) {
+                if (openMarkdownPreviewUseMPE) { // MPE で Preview を開く
+                    await vscode.commands.executeCommand('markdown-preview-enhanced.openPreview').then(() =>{
+                        vscode.commands.executeCommand('workbench.action.focusPreviousGroup');
+                    });
+                } else {
+                    await vscode.commands.executeCommand('markdown.showPreviewToSide').then(() =>{
+                        vscode.commands.executeCommand('workbench.action.focusPreviousGroup');
                     });
                 }
+            } else {
+                // Markdown preview を閉じる
                 await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-                return void 0;
             }
-                await vscode.workspace.openTextDocument(path.normalize(selected.filename)).then(async document => {
-                    await vscode.window.showTextDocument(document, {
-                            viewColumn: 1,
-                            preserveFocus: true,
-                            preview: true
-                        }).then(async editor => {
-                            if (listMarkdownPreview) {
-                                if (openMarkdownPreview) {
-                                // vscode.window.showTextDocument(document, vscode.ViewColumn.One, false).then(editor => {
-                                    // Markdown-Enhance
-                                    // await vscode.commands.executeCommand('markdown.showPreviewToSide').then(() =>{
-                                    await vscode.commands.executeCommand('markdown-preview-enhanced.openPreview').then(() =>{
-                                        vscode.commands.executeCommand('workbench.action.focusPreviousGroup');
-                                    });
-                                // });
-                                } else {
-                                    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-                                }
-                            } else if (openMarkdownPreview) {
-                                await vscode.commands.executeCommand('markdown.showPreviewToSide').then(() => {
-                                    vscode.commands.executeCommand('workbench.action.focusPreviousGroup');
-                                });
-                            }
-                        });
-                });
         });
     }
 }


### PR DESCRIPTION
#36 

Add setting: `memo-life-for-you.openMarkdownPreviewUseMPE`: If `memo-life-for-you.openMarkdownPreview` is set to `true`, use `Markdown Preview Enhanced` (https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced) to open preview (default: false)"