### PR TITLE
Remove unnecessary trailing space when the editor has no selection

### DIFF
--- a/src/memoNew.ts
+++ b/src/memoNew.ts
@@ -164,7 +164,7 @@ export class memoNew extends memoConfigure  {
                                 + getISOWeek
                                 + getEmoji
                                 + dateFns.format(new Date(), `${dateFormat}`)
-                                + " " + `${selectString.substr(0,49)}`
+                                + (selectString === "" ? "" : ` ${selectString.substr(0,49)}`)
                                 + os.EOL + os.EOL);
                         }).then(() => {
                             setTimeout(() => { vscode.commands.executeCommand('workbench.action.closeActiveEditor'); }, 900);
@@ -196,7 +196,7 @@ export class memoNew extends memoConfigure  {
                                 + getISOWeek
                                 + getEmoji
                                 + dateFns.format(new Date(), `${dateFormat}`)
-                                + " " + `${selectString.substr(0,49)}`
+                                + (selectString === "" ? "" : ` ${selectString.substr(0,49)}`)
                                 + os.EOL + os.EOL);
                         }).then(() => {
                             editor.revealRange(editor.selection, vscode.TextEditorRevealType.Default);


### PR DESCRIPTION
Hi, thanks for developing and publishing this nice VS Code extension! I've been using it on a daily basis 🤝 

Recently, I found that if the active editor has no selection, `memoNew` will leave an unnecessary trailing space at the end of each section title. It might look somewhat noticeable especially if you have an extension installed that alerts trailing whitespaces, as below:

<img width="456" alt="Screen Shot 2021-04-10 at 14 16 07" src="https://user-images.githubusercontent.com/27441/114259353-5156f000-9a08-11eb-8a72-3ff5e75c8c65.png">

This PR proposes removing such trailing spaces.