### PR TITLE
Add setting: memo-life-for-you.titlePrefix

### DIFF
--- a/i18n/jpn/package.i18n.json
+++ b/i18n/jpn/package.i18n.json
@@ -12,6 +12,7 @@
 	"extension.memoOpenTypora.title": "Memo: Typora で開く",
     "memoPath.desc": "memo コマンドへの絶対パス。Serve コマンドを使用する場合に必要",
     "serve-addr.desc": "Memo:Serve コマンドで使用するポート番号を指定する",
+    "titlePrefix.desc": "`Memo: 今日のメモ` 実行時、タイトルの先頭に指定した文字列を自動的に挿入します",
     "dateFormat.desc": "date-fns の形式に従ってください。詳細: https://date-fns.org/v2.16.1/docs/format",
     "insertISOWeek.desc": "`Memo: 今日のメモ` 実行時、タイトルに ISO 週番号を自動的に挿入します",
     "insertEmoji.desc": "`Memo: 今日のメモ` 実行時、タイトルにランダムな絵文字を自動的に挿入します",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,11 @@
           "default": "8080",
           "description": "%serve-addr.desc%"
         },
+        "memo-life-for-you.titlePrefix": {
+          "type": "string",
+          "default": "## ",
+          "description": "%titlePrefix.desc%"
+        },
         "memo-life-for-you.dateFormat": {
           "type": "string",
           "default": "yyyy-MM-dd ddd HH:mm",

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,6 +12,7 @@
     "extension.memoOpenTypora.title": "Memo: Open Typora",
     "memoPath.desc": "Absolute path to the memo command",
     "serve-addr.desc": "Specify port number to `Memo: Serve`",
+    "titlePrefix.desc": "When executing `Memo: Today's Quick Memo`, it automatically inserts the specified prefix string of the title",
     "dateFormat.desc": "Follow format of date-fns. See: https://date-fns.org/v2.16.1/docs/format",
     "insertISOWeek.desc": "When executing `Memo: Today's Quick Memo`, it automatically inserts ISO Week number in the title",
     "insertEmoji.desc": "When executing `Memo: Today's Quick Memo`, it automatically inserts random-emoji in the title",

--- a/src/memoConfigure.ts
+++ b/src/memoConfigure.ts
@@ -28,6 +28,7 @@ export class memoConfigure {
     public memodir: string;
     public memotemplate: string;
     public memoconfdir: string;
+    public memoTitlePrefix: string;
     public memoDateFormat: string;
     public memoISOWeek: boolean = false;
     public memoEmoji: boolean = false;
@@ -164,6 +165,7 @@ export class memoConfigure {
     public updateConfiguration() {
         this.memopath = upath.normalize(vscode.workspace.getConfiguration('memo-life-for-you').get<string>('memoPath'));
         this.memoaddr = vscode.workspace.getConfiguration('memo-life-for-you').get<string>('serve-addr');
+        this.memoTitlePrefix = vscode.workspace.getConfiguration('memo-life-for-you').get<string>('titlePrefix');
         this.memoDateFormat = vscode.workspace.getConfiguration('memo-life-for-you').get<string>('dateFormat');
         this.memoISOWeek = vscode.workspace.getConfiguration('memo-life-for-you').get<boolean>('insertISOWeek');
         this.memoEmoji = vscode.workspace.getConfiguration('memo-life-for-you').get<boolean>('insertEmoji');

--- a/src/memoNew.ts
+++ b/src/memoNew.ts
@@ -129,6 +129,7 @@ export class memoNew extends memoConfigure  {
         let file: string = upath.normalize(upath.join(this.memodir, dateFns.format(new Date(), 'yyyy-MM-dd') + ".md"));
         let date: Date = new Date();
         let dateFormat = this.memoDateFormat;
+        let titlePrefix = this.memoTitlePrefix;
         let getISOWeek = this.memoISOWeek == true ? "[Week: " + dateFns.getISOWeek(new Date()) + "/" + dateFns.getISOWeeksInYear(new Date()) + "] " : "";
         let getEmoji = this.memoEmoji == true ? randomEmoji.random().emoji : "";
 
@@ -160,7 +161,8 @@ export class memoNew extends memoConfigure  {
                     editor.selection = new vscode.Selection(newPosition, newPosition);
                         vscode.window.activeTextEditor.edit(async function (edit) {
                             edit.insert(newPosition,
-                                os.EOL + "## "
+                                os.EOL
+                                + titlePrefix 
                                 + getISOWeek
                                 + getEmoji
                                 + dateFns.format(new Date(), `${dateFormat}`)
@@ -192,7 +194,8 @@ export class memoNew extends memoConfigure  {
                     editor.selection = new vscode.Selection(newPosition, newPosition);
                         vscode.window.activeTextEditor.edit(function (edit) {
                             edit.insert(newPosition,
-                                os.EOL + "## "
+                                os.EOL
+                                + titlePrefix 
                                 + getISOWeek
                                 + getEmoji
                                 + dateFns.format(new Date(), `${dateFormat}`)


### PR DESCRIPTION
Add setting: `memo-life-for-you.titlePrefix`.

By default, `## ` is inserted for the title prefix. But I want to customize its prefix, so I added the configuration option for `titlePrefix`. Default behavior does not changed(`## ` is inserted).